### PR TITLE
Support for ES6 promises and mongoose options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save mongoose
 ## Usage
 ```
 var options = {
-    bluebird: false,
+    promises: 'native',
     uri: 'mongodb://localhost:27017'
 };
 
@@ -59,6 +59,7 @@ small.save(function (err) {
 It is important to use ```server.plugins['hapi-mongoose'].lib``` instead of ```require('mongoose')``` due to [this issue](https://github.com/Automattic/mongoose/issues/2669).
 
 ## Options
-* bluebird - setting this option to true will use bluebird promises in place of mongoose's built in 'mpromise'. [Read More](http://mongoosejs.com/docs/promises.html)
-* uri
+* promises - Choose your promises implementation. Valid string options are 'bluebird', 'native'/'es6'. Any other value will result in the use of mongoose's built in 'mpromise'. [Read More](http://mongoosejs.com/docs/promises.html)
+* uri - Your mongo uris [Read More](http://mongoosejs.com/docs/connections.html)
+* mongooseOptions - A javascript opbject with mongoose connection options [Read More](http://mongoosejs.com/docs/connections.html#options)
 [MongoDB uri](https://docs.mongodb.org/v3.0/reference/connection-string/)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ small.save(function (err) {
 It is important to use ```server.plugins['hapi-mongoose'].lib``` instead of ```require('mongoose')``` due to [this issue](https://github.com/Automattic/mongoose/issues/2669).
 
 ## Options
-* promises - Choose your promises implementation. Valid string options are 'bluebird', 'native'/'es6'. Any other value will result in the use of mongoose's built in 'mpromise'. [Read More](http://mongoosejs.com/docs/promises.html)
+* promises - Choose your promises implementation. Valid string options are 'bluebird', 'native' (or 'es6'). Any other value will result in the use of mongoose's built in 'mpromise'. [Read More](http://mongoosejs.com/docs/promises.html)
 * uri - Your mongo uris [Read More](http://mongoosejs.com/docs/connections.html)
 * mongooseOptions - A javascript opbject with mongoose connection options [Read More](http://mongoosejs.com/docs/connections.html#options)
 [MongoDB uri](https://docs.mongodb.org/v3.0/reference/connection-string/)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,5 @@ It is important to use ```server.plugins['hapi-mongoose'].lib``` instead of ```r
 
 ## Options
 * promises - Choose your promises implementation. Valid string options are 'bluebird', 'native' (or 'es6'). Any other value will result in the use of mongoose's built in 'mpromise'. [Read More](http://mongoosejs.com/docs/promises.html)
-* uri - Your mongo uris [Read More](http://mongoosejs.com/docs/connections.html)
-* mongooseOptions - A javascript opbject with mongoose connection options [Read More](http://mongoosejs.com/docs/connections.html#options)
-[MongoDB uri](https://docs.mongodb.org/v3.0/reference/connection-string/)
+* uri - [MongoDB uri](https://docs.mongodb.org/v3.0/reference/connection-string/)
+* mongooseOptions - A javascript opbject with mongoose connection options. [Read More](http://mongoosejs.com/docs/connections.html#options)

--- a/lib/MongooseConnector.js
+++ b/lib/MongooseConnector.js
@@ -14,7 +14,7 @@ class MongooseConnector extends EventEmitter {
       mongoose.Promise = global.Promise;
     }
     this.mongoose = mongoose;
-    this.connection = mongoose.createConnection(options.uri);
+    this.connection = mongoose.createConnection(options.uri, options.mongooseOptions);
 
     this.connection.on('connected', () => {
       plugin.log(['info', 'database', 'mongoose', 'mongodb'], 'Connected');

--- a/lib/MongooseConnector.js
+++ b/lib/MongooseConnector.js
@@ -8,8 +8,10 @@ class MongooseConnector extends EventEmitter {
   constructor (options, plugin) {
     super();
 
-    if (options.bluebird === true) {
+    if (options.promises === 'bluebird') {
       mongoose.Promise = require('bluebird');
+    } else if (options.promises === 'native' || options.promises === 'es6') {
+      mongoose.Promise = global.Promise;
     }
     this.mongoose = mongoose;
     this.connection = mongoose.createConnection(options.uri);

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const internals = {};
 
 internals.defaults = {
   uri: 'mongodb://127.0.0.1:27017',
-  bluebird: false // use built-in mpromises by default
+  promises: 'mpromises' // use built-in mpromises by default
 };
 
 exports.register = (server, options, next) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,8 @@ const internals = {};
 
 internals.defaults = {
   uri: 'mongodb://127.0.0.1:27017',
-  promises: 'mpromises' // use built-in mpromises by default
+  promises: 'mpromises', // use built-in mpromises by default
+  mongooseOptions: {}
 };
 
 exports.register = (server, options, next) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var MongooseConnector = require('./MongooseConnector');
 const internals = {};
 
 internals.defaults = {
-  uri: 'mongodb://126.0.0.1:27017',
+  uri: 'mongodb://127.0.0.1:27017',
   bluebird: false // use built-in mpromises by default
 };
 

--- a/test/MongooseConnector.js
+++ b/test/MongooseConnector.js
@@ -86,7 +86,7 @@ describe('With es6 (es6)', () => {
       log: log => log
     };
     MongooseConnector.__set__('mongoose', mongooseEmitter);
-    mongooseConnector = new MongooseConnector({promises: 'es'}, pluginStub);
+    mongooseConnector = new MongooseConnector({promises: 'es6'}, pluginStub);
     done();
   });
 

--- a/test/MongooseConnector.js
+++ b/test/MongooseConnector.js
@@ -97,6 +97,27 @@ describe('With es6 (es6)', () => {
   });
 });
 
+describe('With es6 (native)', () => {
+  let mongooseConnector, mongooseEmitter, pluginStub; //eslint-disable-line
+  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+
+  beforeEach(done => {
+    mongooseEmitter = new MongooseEmitter('connected');
+    pluginStub = {
+      log: log => log
+    };
+    MongooseConnector.__set__('mongoose', mongooseEmitter);
+    mongooseConnector = new MongooseConnector({promises: 'native'}, pluginStub);
+    done();
+  });
+
+  it('is an instance of EventEmitter', done => {
+    expect(mongooseEmitter.Promise).to.equal(global.Promise);
+
+    done();
+  });
+});
+
 describe('Default Options with failed connection', () => {
   let mongooseConnector, mongooseEmitter, logSpy, pluginStub;
   let MongooseEmitter = require('./artifacts/MongooseEmitter');

--- a/test/MongooseConnector.js
+++ b/test/MongooseConnector.js
@@ -76,6 +76,27 @@ describe('With bluebird (bluebird)', () => {
   });
 });
 
+describe('With es6 (es6)', () => {
+  let mongooseConnector, mongooseEmitter, pluginStub; //eslint-disable-line
+  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+
+  beforeEach(done => {
+    mongooseEmitter = new MongooseEmitter('connected');
+    pluginStub = {
+      log: log => log
+    };
+    MongooseConnector.__set__('mongoose', mongooseEmitter);
+    mongooseConnector = new MongooseConnector({promises: 'es'}, pluginStub);
+    done();
+  });
+
+  it('is an instance of EventEmitter', done => {
+    expect(mongooseEmitter.Promise).to.equal(global.Promise);
+
+    done();
+  });
+});
+
 describe('Default Options with failed connection', () => {
   let mongooseConnector, mongooseEmitter, logSpy, pluginStub;
   let MongooseEmitter = require('./artifacts/MongooseEmitter');

--- a/test/MongooseConnector.js
+++ b/test/MongooseConnector.js
@@ -27,7 +27,7 @@ describe('Default Options', () => {
     };
     logSpy = sinon.spy(pluginStub, 'log');
     MongooseConnector.__set__('mongoose', mongooseEmitter);
-    mongooseConnector = new MongooseConnector({bluebird: false}, pluginStub);
+    mongooseConnector = new MongooseConnector({promises: 'mpromise'}, pluginStub);
     done();
   });
 
@@ -65,7 +65,7 @@ describe('With bluebird (bluebird)', () => {
       log: log => log
     };
     MongooseConnector.__set__('mongoose', mongooseEmitter);
-    mongooseConnector = new MongooseConnector({bluebird: true}, pluginStub);
+    mongooseConnector = new MongooseConnector({promises: 'bluebird'}, pluginStub);
     done();
   });
 
@@ -87,7 +87,7 @@ describe('Default Options with failed connection', () => {
     };
     logSpy = sinon.spy(pluginStub, 'log');
     MongooseConnector.__set__('mongoose', mongooseEmitter);
-    mongooseConnector = new MongooseConnector({bluebird: false}, pluginStub);
+    mongooseConnector = new MongooseConnector({promises: 'mpromise'}, pluginStub);
     mongooseConnector.on('error', err => err);
     done();
   });
@@ -123,7 +123,7 @@ describe('Default Options with closed connection', () => {
     };
     logSpy = sinon.spy(pluginStub, 'log');
     MongooseConnector.__set__('mongoose', mongooseEmitter);
-    mongooseConnector = new MongooseConnector({bluebird: false}, pluginStub);
+    mongooseConnector = new MongooseConnector({promises: 'mpromise'}, pluginStub);
     mongooseConnector.on('error', err => err);
     done();
   });
@@ -151,7 +151,7 @@ describe('Default Options with disconnected connection', () => {
     };
     logSpy = sinon.spy(pluginStub, 'log');
     MongooseConnector.__set__('mongoose', mongooseEmitter);
-    mongooseConnector = new MongooseConnector({bluebird: false}, pluginStub);
+    mongooseConnector = new MongooseConnector({promises: 'mpromise'}, pluginStub);
     mongooseConnector.on('error', err => err);
     done();
   });


### PR DESCRIPTION
This adds support for ES6 promises and mongoose connection options. I've updated the README accordingly.
