### PR TITLE
createConnection error handling

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: v4.2.2
+    version: v8.9.4

--- a/lib/MongooseConnector.js
+++ b/lib/MongooseConnector.js
@@ -11,12 +11,18 @@ class MongooseConnector extends EventEmitter {
       mongoose.Promise = global.Promise;
     }
     this.mongoose = mongoose;
-    this.connection = mongoose.createConnection(options.uri, options.mongooseOptions);
+    this.connection = mongoose.createConnection(options.uri, options.mongooseOptions, (err) => {
+      if (err) {
+        plugin.log(['error', 'database', 'mongoose', 'mongodb'], `error during initial connect ${err}`);
+        this.emit('error', err);
+      }
+    });
 
-    this.connection.on('connected', () => {
-      plugin.log(['info', 'database', 'mongoose', 'mongodb'], 'Connected');
-      this.emit('ready');
-    })
+    this.connection
+      .on('connected', () => {
+        plugin.log(['info', 'database', 'mongoose', 'mongodb'], 'Connected');
+        this.emit('ready');
+      })
       .on('error', err => {
         plugin.log(['error', 'database', 'mongoose', 'mongodb'], `Unable to connect to database: ${err.message}`);
         this.emit('error', err);

--- a/test/MongooseConnector.js
+++ b/test/MongooseConnector.js
@@ -16,7 +16,7 @@ const expect = Code.expect;
 
 describe('Default Options', () => {
   let mongooseConnector, mongooseEmitter, logSpy, pluginStub;
-  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+  let MongooseEmitter = require('./artifacts/MongooseStub');
 
   beforeEach(() => {
     mongooseEmitter = new MongooseEmitter('connected');
@@ -48,7 +48,7 @@ describe('Default Options', () => {
 
 describe('With bluebird (bluebird)', () => {
   let mongooseConnector, mongooseEmitter, pluginStub; //eslint-disable-line
-  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+  let MongooseEmitter = require('./artifacts/MongooseStub');
 
   beforeEach(() => {
     mongooseEmitter = new MongooseEmitter('connected');
@@ -66,7 +66,7 @@ describe('With bluebird (bluebird)', () => {
 
 describe('With es6 (es6)', () => {
   let mongooseConnector, mongooseEmitter, pluginStub; //eslint-disable-line
-  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+  let MongooseEmitter = require('./artifacts/MongooseStub');
 
   beforeEach(() => {
     mongooseEmitter = new MongooseEmitter('connected');
@@ -84,7 +84,7 @@ describe('With es6 (es6)', () => {
 
 describe('With es6 (native)', () => {
   let mongooseConnector, mongooseEmitter, pluginStub; //eslint-disable-line
-  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+  let MongooseEmitter = require('./artifacts/MongooseStub');
 
   beforeEach(() => {
     mongooseEmitter = new MongooseEmitter('connected');
@@ -102,7 +102,7 @@ describe('With es6 (native)', () => {
 
 describe('Default Options with failed connection', () => {
   let mongooseConnector, mongooseEmitter, logSpy, pluginStub;
-  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+  let MongooseEmitter = require('./artifacts/MongooseStub');
 
   beforeEach(() => {
     mongooseEmitter = new MongooseEmitter('error', { message: 'test' });
@@ -133,7 +133,7 @@ describe('Default Options with failed connection', () => {
 
 describe('Default Options with closed connection', () => {
   let mongooseConnector, mongooseEmitter, logSpy, pluginStub;
-  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+  let MongooseEmitter = require('./artifacts/MongooseStub');
 
   beforeEach(() => {
     mongooseEmitter = new MongooseEmitter('close');
@@ -158,7 +158,7 @@ describe('Default Options with closed connection', () => {
 
 describe('Default Options with disconnected connection', () => {
   let mongooseConnector, mongooseEmitter, logSpy, pluginStub;
-  let MongooseEmitter = require('./artifacts/MongooseEmitter');
+  let MongooseEmitter = require('./artifacts/MongooseStub');
 
   beforeEach(() => {
     mongooseEmitter = new MongooseEmitter('disconnected');

--- a/test/MongooseConnector.js
+++ b/test/MongooseConnector.js
@@ -46,6 +46,33 @@ describe('Default Options', () => {
   });
 });
 
+describe('Default Options with initial connect error', () => {
+  let mongooseConnector, mongooseEmitter, logSpy, pluginStub;
+  let FailingMongooseEmitter = require('./artifacts/FailingMongooseStub');
+
+  beforeEach(() => {
+    mongooseEmitter = new FailingMongooseEmitter('connected');
+    pluginStub = {
+      log: log => log
+    };
+    logSpy = sinon.spy(pluginStub, 'log');
+    MongooseConnector.__set__('mongoose', mongooseEmitter);
+    mongooseConnector = new MongooseConnector({ promises: 'mpromise' }, pluginStub);
+  });
+
+  it('logs and emits error', async () => {
+    mongooseConnector.on('error', (err) => {
+      expect(err.message).to.equal('I can only fail');
+    });
+    await new Promise((resolve, reject) => setTimeout(() => resolve(), 5));
+
+    const args = logSpy.getCall(0).args;
+
+    expect(args[0][0]).to.equal('error');
+    expect(args[1]).to.contain('I can only fail');
+  });
+});
+
 describe('With bluebird (bluebird)', () => {
   let mongooseConnector, mongooseEmitter, pluginStub; //eslint-disable-line
   let MongooseEmitter = require('./artifacts/MongooseStub');

--- a/test/artifacts/FailingMongooseStub.js
+++ b/test/artifacts/FailingMongooseStub.js
@@ -3,7 +3,7 @@ const MongooseStub = require('./MongooseStub');
 
 class FailingMongooseStub extends MongooseStub {
   createConnection (uri, opts, cb) {
-    setImmediate(() => cb(new Error('I can only fail')));
+    setTimeout(() => cb(new Error('I can only fail')), 2);
     return new MongooseEmitter(this.eventToEmit, this.eventArgs);
   }
 }

--- a/test/artifacts/FailingMongooseStub.js
+++ b/test/artifacts/FailingMongooseStub.js
@@ -1,0 +1,11 @@
+const MongooseEmitter = require('./MongooseEmitter');
+const MongooseStub = require('./MongooseStub');
+
+class FailingMongooseStub extends MongooseStub {
+  createConnection (uri, opts, cb) {
+    setImmediate(() => cb(new Error('I can only fail')));
+    return new MongooseEmitter(this.eventToEmit, this.eventArgs);
+  }
+}
+
+module.exports = FailingMongooseStub;

--- a/test/artifacts/MongooseEmitter.js
+++ b/test/artifacts/MongooseEmitter.js
@@ -3,21 +3,8 @@ const EventEmitter = require('events').EventEmitter;
 class MongooseEmitter extends EventEmitter {
   constructor (eventToEmit, eventArgs) {
     super();
-
     setTimeout(() => this.emit(eventToEmit, eventArgs), 2);
   }
 }
 
-class MongooseStub {
-  constructor (eventToEmit, eventArgs) {
-    this.eventToEmit = eventToEmit;
-    this.eventArgs = eventArgs;
-    this.promise = null;
-  }
-
-  createConnection () {
-    return new MongooseEmitter(this.eventToEmit, this.eventArgs);
-  }
-}
-
-module.exports = MongooseStub;
+module.exports = MongooseEmitter;

--- a/test/artifacts/MongooseStub.js
+++ b/test/artifacts/MongooseStub.js
@@ -1,0 +1,15 @@
+const MongooseEmitter = require('./MongooseEmitter');
+
+class MongooseStub {
+  constructor (eventToEmit, eventArgs) {
+    this.eventToEmit = eventToEmit;
+    this.eventArgs = eventArgs;
+    this.promise = null;
+  }
+
+  createConnection () {
+    return new MongooseEmitter(this.eventToEmit, this.eventArgs);
+  }
+}
+
+module.exports = MongooseStub;

--- a/test/artifacts/MongooseStub.js
+++ b/test/artifacts/MongooseStub.js
@@ -7,7 +7,8 @@ class MongooseStub {
     this.promise = null;
   }
 
-  createConnection () {
+  createConnection (a, b, cb) {
+    cb(null, ''); // provide this non-error callback so Lab can see that we are testing all of the code in the error callback on createConnection
     return new MongooseEmitter(this.eventToEmit, this.eventArgs);
   }
 }


### PR DESCRIPTION
This PR adds support for handling mongo errors when calling `mongoose.createConnection(...)`. If things go haywire here (mongo down, network issues, etc) , a callback is triggered / promise throw, which when unhandled leads to:

```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): 
MongoNetworkError: failed to connect to server [localhost:27017] on first connect 
[MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017

[DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. 
In the future, promise rejections that are not handled will terminate the Node.js 
proc
```

Also this terminates the node process if `make-promises-safe` has been registered.

The callback handles the error by logging and emitting an error event - then it's up to the consumer to figure out what to do.