### PR TITLE
Update MongoDB documentation link in README and fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # hapi-mongoose
+
 [![Circle CI](https://img.shields.io/circleci/project/asilluron/hapi-mongoose/master.svg?style=flat-square)](https://circleci.com/gh/asilluron/hapi-mongoose/tree/master)
 
 [![Stories in Ready](https://badge.waffle.io/asilluron/hapi-mongoose.svg?label=ready&title=Ready&style=flat-square)](http://waffle.io/asilluron/hapi-mongoose)
 
-Hapi Plugin to handle Mongoose handshake and initial setup
+An hapi plugin to handle Mongoose handshake and initial setup.
+
 ## Install
+
 ```
 npm install --save hapi-mongoose
 ```
+
 ## Requirements
+
 * Mongoose
+
 ```
 npm install --save mongoose
 ```
 
 ## Usage
+
 ```javascript
 const options = {
     promises: 'native',
@@ -34,13 +41,14 @@ const mongoose = server.plugins['hapi-mongoose'].lib;
 ```
 
 ### Example
+
 ```javascript
 const db = server.plugins['hapi-mongoose'].connection; // Get the current connection for this server instance
 const mongoose = server.plugins['hapi-mongoose'].lib;
 const Schema = mongoose.Schema;
 
 const tankSchema = new Schema({
-  //tank props
+  // Tank properties
 });
 
 const Tank = db.model('Tank', tankSchema);
@@ -49,15 +57,14 @@ const small = new Tank({ size: 'small' });
 
 small.save(function (err) {
   if (err) return handleError(err);
-  // saved!
+  // Saved!
 });
 ```
-
-
 
 It is important to use ```server.plugins['hapi-mongoose'].lib``` instead of ```require('mongoose')``` due to [this issue](https://github.com/Automattic/mongoose/issues/2669).
 
 ## Options
-* promises - Choose your promises implementation. Valid string options are 'bluebird', 'native' (or 'es6'). Any other value will result in the use of mongoose's built in 'mpromise'. [Read More](http://mongoosejs.com/docs/promises.html)
-* uri - [MongoDB uri](https://docs.mongodb.org/v3.0/reference/connection-string/)
-* mongooseOptions - A javascript opbject with mongoose connection options. [Read More](http://mongoosejs.com/docs/connections.html#options)
+
+* `promises` - Choose your promises implementation. Valid string options are `bluebird`, `native` (or `es6`). Any other value will result in the use of Mongoose's built-in `mpromise` ([read more](http://mongoosejs.com/docs/promises.html)).
+* `uri` - A [MongoDB connection string](https://docs.mongodb.org/v4.0/reference/connection-string/).
+* `mongooseOptions` - A JavaScript object with [Mongoose connection options](http://mongoosejs.com/docs/connections.html#options).


### PR DESCRIPTION
This updates a link that pointed to MongoDB 3.0 documentation to 4.0, as 3.0 is no longer maintained.

Also, it looks like the official casing is "hapi" instead of "Hapi", so I replaced it in the description.